### PR TITLE
Redirect viewer link to client api download

### DIFF
--- a/link-converter/.gitignore
+++ b/link-converter/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.DS_Store
+*.log
+.netlify

--- a/link-converter/README.md
+++ b/link-converter/README.md
@@ -1,0 +1,17 @@
+# Conversor de Link MobileMed
+
+Converte links do OneLaudos para o link de download ZIP do PMSBC.
+
+- Entrada: 
+- Saída:  
+
+## Uso local
+Abra  no navegador ou sirva com um servidor estático.
+
+## Deploy no Netlify
+1. Suba estes arquivos para um repositório Git (ou faça upload direto no Netlify).
+2. No Netlify: Add new site → Import from Git.
+3. Build command: (deixe em branco)
+4. Publish directory: diretório raiz (contém ).
+
+Também é possível arrastar e soltar a pasta no painel do Netlify (Deploy manual).

--- a/link-converter/index.html
+++ b/link-converter/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Conversor de Link MobileMed</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>Conversor de Link MobileMed</h1>
+    <p>Cole o link do OneLaudos para gerar o link de download Zip do PMSBC.</p>
+    <label for="input-url" class="visualmente-oculto">URL do OneLaudos</label>
+    <input id="input-url" type="url" placeholder="https://onelaudos.mobilemed.com.br/viewer/XY/8476206/427" autocomplete="off">
+    <div class="acoes">
+      <button id="convert-btn">Converter</button>
+      <button id="clear-btn" class="secundario">Limpar</button>
+    </div>
+    <div id="result" class="resultado oculto">
+      <label for="output-url">URL gerada</label>
+      <input id="output-url" type="text" readonly>
+      <div class="acoes">
+        <button id="copy-btn" class="secundario">Copiar</button>
+        <a id="open-btn" class="link-botao" target="_blank" rel="noopener noreferrer">Abrir</a>
+      </div>
+    </div>
+    <p class="dica">Formato esperado: <code>https://onelaudos.mobilemed.com.br/viewer/XY/...</code></p>
+    <details>
+      <summary>Como funciona?</summary>
+      <p>Extraímos o identificador "XY" do link do OneLaudos e montamos o link de download: <code>https://pmsbc.mobilemed.com.br/client-api/patients/download/zip?studyUID=XY</code>.</p>
+    </details>
+  </main>
+  <script src="./script.js"></script>
+</body>
+</html>
+

--- a/link-converter/netlify.toml
+++ b/link-converter/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "/**"
+  to = "/index.html"
+  status = 200
+

--- a/link-converter/script.js
+++ b/link-converter/script.js
@@ -1,0 +1,76 @@
+(function () {
+  function $(selector) { return document.querySelector(selector); }
+
+  var input = $('#input-url');
+  var output = $('#output-url');
+  var result = $('#result');
+  var convertBtn = $('#convert-btn');
+  var clearBtn = $('#clear-btn');
+  var copyBtn = $('#copy-btn');
+  var openBtn = $('#open-btn');
+
+  function extractStudyUID(url) {
+    try {
+      var u = new URL(url);
+      if (!/^(https?:)?\/\/onelaudos\.mobilemed\.com\.br$/i.test(u.origin)) return null;
+      var parts = u.pathname.split('/').filter(Boolean);
+      var viewerIndex = parts.indexOf('viewer');
+      if (viewerIndex === -1 || viewerIndex + 1 >= parts.length) return null;
+      var xy = parts[viewerIndex + 1];
+      if (!xy || !/^\d+(?:\.\d+)+$/.test(xy)) return null;
+      return xy;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function buildPmsbcUrl(studyUID) {
+    var base = 'https://pmsbc.mobilemed.com.br/client-api/patients/download/zip';
+    var params = new URLSearchParams({ studyUID: studyUID });
+    return base + '?' + params.toString();
+  }
+
+  function convert() {
+    var value = (input.value || '').trim();
+    var uid = extractStudyUID(value);
+    if (!uid) {
+      result.classList.add('oculto');
+      alert('URL inválida. Use um link do OneLaudos: https://onelaudos.mobilemed.com.br/viewer/XY/...');
+      return;
+    }
+    var finalUrl = buildPmsbcUrl(uid);
+    output.value = finalUrl;
+    openBtn.href = finalUrl;
+    result.classList.remove('oculto');
+  }
+
+  function clearAll() {
+    input.value = '';
+    output.value = '';
+    result.classList.add('oculto');
+    input.focus();
+  }
+
+  function copy() {
+    if (!output.value) return;
+    navigator.clipboard.writeText(output.value).then(function () {
+      copyBtn.textContent = 'Copiado!';
+      setTimeout(function () { copyBtn.textContent = 'Copiar'; }, 1200);
+    });
+  }
+
+  convertBtn.addEventListener('click', convert);
+  clearBtn.addEventListener('click', clearAll);
+  copyBtn.addEventListener('click', copy);
+  input.addEventListener('keydown', function (ev) {
+    if (ev.key === 'Enter') { ev.preventDefault(); convert(); }
+  });
+
+  // Auto-converter se houver ?url= na query string
+  try {
+    var qs = new URLSearchParams(location.search);
+    var pre = qs.get('url');
+    if (pre) { input.value = pre; convert(); }
+  } catch (e) { /* ignore */ }
+})();
+

--- a/link-converter/styles.css
+++ b/link-converter/styles.css
@@ -1,0 +1,102 @@
+:root {
+  --bg: #0b1020;
+  --card: #111833;
+  --text: #e6e8ef;
+  --muted: #a3acc4;
+  --accent: #6ea8fe;
+  --accent-2: #7bdebd;
+  --border: #2a3357;
+}
+
+* { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(1200px 600px at 10% 0, rgba(110,168,254,.25), transparent),
+    radial-gradient(1200px 600px at 90% -10%, rgba(123,222,189,.25), transparent),
+    var(--bg);
+}
+
+.container {
+  max-width: 720px;
+  margin: 6rem auto;
+  padding: 2rem;
+  background: linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,.02));
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(0,0,0,.25);
+}
+
+h1 { margin: 0 0 1rem; font-size: 1.75rem; }
+p { margin: .25rem 0 1rem; color: var(--muted); }
+.dica { margin-top: 1.5rem; font-size: .9rem; }
+
+.visualmente-oculto {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+input {
+  width: 100%;
+  padding: .85rem 1rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: #0d1533;
+  color: var(--text);
+  outline: none;
+  transition: border-color .2s, box-shadow .2s;
+}
+input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(110,168,254,.2); }
+
+.acoes { display: flex; gap: .75rem; margin-top: 1rem; }
+
+button, .link-botao {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: .5rem;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  padding: .7rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+button {
+  background: linear-gradient(180deg, var(--accent), #4d86ea);
+  color: #0a1631;
+  border-color: #4d86ea;
+}
+
+button.secundario {
+  background: transparent;
+  color: var(--text);
+  border-color: var(--border);
+}
+
+button:hover { filter: brightness(1.05); }
+button:active { transform: translateY(1px); }
+
+.link-botao {
+  background: linear-gradient(180deg, var(--accent-2), #2eb38b);
+  color: #062319;
+  border-color: #2eb38b;
+}
+
+.resultado { margin-top: 1.25rem; }
+.resultado.oculto { display: none; }
+
+label { display: block; margin: .25rem 0 .4rem; color: var(--muted); }
+code { background: #0d1533; padding: .15rem .35rem; border-radius: 6px; border: 1px solid var(--border); color: var(--accent); }
+
+details { margin-top: 1.25rem; border-top: 1px dashed var(--border); padding-top: 1rem; }
+summary { cursor: pointer; }
+


### PR DESCRIPTION
Add a static site to convert OneLaudos viewer URLs into PMSBC download links, as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-56202f31-5d54-473d-96c6-de7055d05392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-56202f31-5d54-473d-96c6-de7055d05392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

